### PR TITLE
Internationalization for inzane_syllabus sidebar.

### DIFF
--- a/Inzane_Syllabus/inzaneSyllabus-UKenglish.ldf
+++ b/Inzane_Syllabus/inzaneSyllabus-UKenglish.ldf
@@ -1,0 +1,3 @@
+\ProvidesFile{inzaneSyllabus-UKenglish.ldf}
+
+\input{inzaneSyllabus-british.ldf}

--- a/Inzane_Syllabus/inzaneSyllabus-USenglish.ldf
+++ b/Inzane_Syllabus/inzaneSyllabus-USenglish.ldf
@@ -1,0 +1,3 @@
+\ProvidesFile{inzaneSyllabus-USenglish.ldf}
+
+\input{inzaneSyllabus-english.ldf}

--- a/Inzane_Syllabus/inzaneSyllabus-american.ldf
+++ b/Inzane_Syllabus/inzaneSyllabus-american.ldf
@@ -1,0 +1,3 @@
+\ProvidesFile{inzaneSyllabus-american.ldf}
+
+\input{inzaneSyllabus-english.ldf}

--- a/Inzane_Syllabus/inzaneSyllabus-australian.ldf
+++ b/Inzane_Syllabus/inzaneSyllabus-australian.ldf
@@ -1,0 +1,3 @@
+\ProvidesFile{inzaneSyllabus-australian.ldf}
+
+\input{inzaneSyllabus-english.ldf}

--- a/Inzane_Syllabus/inzaneSyllabus-british.ldf
+++ b/Inzane_Syllabus/inzaneSyllabus-british.ldf
@@ -1,0 +1,3 @@
+\ProvidesFile{inzaneSyllabus-british.ldf}
+
+\input{inzaneSyllabus-english.ldf}

--- a/Inzane_Syllabus/inzaneSyllabus-canadian.ldf
+++ b/Inzane_Syllabus/inzaneSyllabus-canadian.ldf
@@ -1,0 +1,3 @@
+\ProvidesFile{inzaneSyllabus-canadian.ldf}
+
+\input{inzaneSyllabus-english.ldf}

--- a/Inzane_Syllabus/inzaneSyllabus-dutch.ldf
+++ b/Inzane_Syllabus/inzaneSyllabus-dutch.ldf
@@ -1,0 +1,5 @@
+\ProvidesFile{inzaneSyllabus-dutch.ldf}
+
+\@namedef{inzaneSyllabus@lang@instructorInfo}{Docentinformatie}%
+\@namedef{inzaneSyllabus@lang@courseInfo}{Vakinformatie}%
+\@namedef{inzaneSyllabus@lang@description}{Omschrijving}%

--- a/Inzane_Syllabus/inzaneSyllabus-english.ldf
+++ b/Inzane_Syllabus/inzaneSyllabus-english.ldf
@@ -1,0 +1,5 @@
+\ProvidesFile{inzaneSyllabus-english.ldf}
+
+\@namedef{inzaneSyllabus@lang@instructorInfo}{Instructor Info}
+\@namedef{inzaneSyllabus@lang@courseInfo}{Course Info}
+\@namedef{inzaneSyllabus@lang@description}{Description}

--- a/Inzane_Syllabus/inzaneSyllabus-newzealand.ldf
+++ b/Inzane_Syllabus/inzaneSyllabus-newzealand.ldf
@@ -1,0 +1,3 @@
+\ProvidesFile{inzaneSyllabus-newzealand.ldf}
+
+\input{inzaneSyllabus-english.ldf}

--- a/Inzane_Syllabus/inzane_syllabus.cls
+++ b/Inzane_Syllabus/inzane_syllabus.cls
@@ -115,6 +115,33 @@
 }
 
 %----------------------------------------------------------------------------------------
+%	 SIDEBAR TRANSLATION FILES
+%----------------------------------------------------------------------------------------
+\AtEndPreamble{
+\ifdefined\inzaneSyllabus@lang%
+  \ifthenelse{\equal{\inzaneSyllabus@lang}{}}{%
+    \renewcommand{\inzaneSyllabus@lang}{\languagename}}{}%
+\else
+  \newcommand{\inzaneSyllabus@lang}{\languagename}%
+\fi
+\IfFileExists{inzaneSyllabus-\inzaneSyllabus@lang.ldf}{%
+  \makeatletter
+  \input{inzaneSyllabus-\inzaneSyllabus@lang.ldf}
+  \makeatother
+  \ClassWarning{inzane_syllabus}{Hi there! \inzaneSyllabus@lang
+  \inzaneSyllabus@lang@instructorInfo
+  \inzaneSyllabus@lang@courseInfo
+  \inzaneSyllabus@lang@description
+  }%
+}{%
+  \PackageWarning{inzane_syllabus}{%
+    No language definition for \inzaneSyllabus@lang found.
+    Please add one and submit a patch. Using English as fallback.}%
+  \renewcommand{\inzaneSyllabus@lang}{english}%
+  \input{inzane_syllabus-\inzaneSyllabus@lang.ldf}%
+}%
+}
+%----------------------------------------------------------------------------------------
 %	 SIDEBAR LAYOUT
 %----------------------------------------------------------------------------------------
 
@@ -153,7 +180,7 @@
 
 		%------------------------------------------------
         
-        \profilesection{Instructor Info}      
+        \profilesection{\inzaneSyllabus@lang@instructorInfo}
         
         \begin{tabular}{p{0.5cm} @{\hskip 0.5cm}p{5cm}}
         	\ifthenelse{\equal{\profname}{}}{}{\textsc{\Large\icon{\WomanFace}} & \profname\\}
@@ -164,7 +191,7 @@
 			\ifthenelse{\equal{\email}{}}{}{\textsc{\large\icon{@}} & \href{mailto:\email}{\email}}
 		\end{tabular}
         
-        \profilesection{Course Info}
+        \profilesection{\inzaneSyllabus@lang@courseInfo}
         
         \begin{tabular}{p{0.5cm} @{\hskip 0.5cm}p{5cm}}
 			\ifthenelse{\equal{\classhours}{}}{}{\textsc{\Large\icon{\ClockLogo}} & \classhours\\}            
@@ -173,7 +200,7 @@
         \end{tabular}
         
 		\ifthenelse{\equal{\about}{}}{}{
-			\profilesection{Description}
+			\profilesection{\inzaneSyllabus@lang@description}
 			\begin{flushleft}
 				\about
 			\end{flushleft}


### PR DESCRIPTION
Defining the document's language with babel will change the words used
for the sections in the sidebar.  Now, all babel's variants for English
are recognized, as well as Dutch.